### PR TITLE
Removed chat PRO.LINUX from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Take a minute and have a look at collection of Open Source Examples, Libraries a
 - [PRO.LISP](https://telegram.me/joinchat/Be4rsTvFzQ4yIktHsNNYrA)
 - [PRO.LUA](https://telegram.me/proLUA)
 - [PRO.Apple](https://telegram.me/proApple)
-- [PRO.Linux](https://telegram.me/joinchat/A2eDLzu6qWFlMl2nLn9SEA)
 - [PRO.Windows](https://telegram.me/joinchat/Be4rsT5IrA8x69FnrpMMvw)
 - [PRO.ASM](https://telegram.me/proAsm)
 - [PRO.CSS](https://telegram.me/procss)


### PR DESCRIPTION
Похоже, чат больше не существует.